### PR TITLE
change dependency on three.js to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/nicolaspanel/three-orbitcontrols-ts/issues"
   },
   "homepage": "https://github.com/nicolaspanel/three-orbitcontrols-ts#readme",
-  "dependencies": {
+  "peerDependencies": {
     "three": "^0.83.0"
   },
   "devDependencies": {


### PR DESCRIPTION
having three.js as a dependency leads to multiple copies of three.js in node_modules of the project when one want a more up to date version of three.js.
the solution is to switch to a peerDependency instead